### PR TITLE
Fix uninitialized driver_is_freetds variable

### DIFF
--- a/django_pyodbc/base.py
+++ b/django_pyodbc/base.py
@@ -214,10 +214,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             else:
                 driver = 'FreeTDS'
 
-            if driver == 'FreeTDS' or driver.endswith('/libtdsodbc.so'):
-                driver_is_freetds = True
-            else:
-                driver_is_freetds = False
+        if driver == 'FreeTDS' or driver.endswith('/libtdsodbc.so'):
+            driver_is_freetds = True
+        else:
+            driver_is_freetds = False
 
         # Microsoft driver names assumed here are:
         # * SQL Server


### PR DESCRIPTION
It appears that in bad6b847 the code above the if statement setting the driver_is_freetds was outdented, but the if statement was not. If 'driver' is specified in options, this causes the driver_is_freetds variable to not be initialized, potentially resulting in an error when it is accessed.
