### PR TITLE
fixes #79

### DIFF
--- a/django_pyodbc/compiler.py
+++ b/django_pyodbc/compiler.py
@@ -338,7 +338,9 @@ class SQLCompiler(compiler.SQLCompiler):
                 buf = paren_buf.pop()
                 
                 # store the expanded paren string
+                buf = re.sub(r'%([^\(])', r'$$$\1', buf)
                 parens[key] = buf% parens
+                parens[key] = re.sub(r'\$\$\$([^\(])', r'%\1', parens[key])
                 #cannot use {} because IBM's DB2 uses {} as quotes
                 paren_buf[paren_depth] += '(%(' + key + ')s)'
             else:


### PR DESCRIPTION
When buf comes with %s (because of the SQL query it receives), `buf% parens` breaks. Here I'm changing the existing `%<anything_other_than_a_parenthesis>` with `$$$<the_thing_that_matched>`, applying `buf% parens` and then changing it back.