### PR TITLE
Change imports to work with Django 1.8.  Deprecate compiler.SQLDateCompiler derivatives.

### DIFF
--- a/django_pyodbc/base.py
+++ b/django_pyodbc/base.py
@@ -23,11 +23,20 @@ if pyodbc_ver < (2, 0, 38, 9999):
     raise ImproperlyConfigured("pyodbc 2.0.38 or newer is required; you have %s" % Database.version)
 
 from django.db import utils
-from django.db.backends import BaseDatabaseWrapper, BaseDatabaseFeatures, BaseDatabaseValidation
+try:
+    from django.db.backends.base.base import BaseDatabaseWrapper
+    from django.db.backends.base.features import  BaseDatabaseFeatures
+    from django.db.backends.base.validation import BaseDatabaseValidation
+except ImportError:
+    # import location prior to Django 1.8
+    from django.db.backends import BaseDatabaseWrapper, BaseDatabaseFeatures, BaseDatabaseValidation
 from django.db.backends.signals import connection_created
+    
 from django.conf import settings
 from django import VERSION as DjangoVersion
-if DjangoVersion[:2] == (1, 7):
+if DjangoVersion[:2] == (1, 8):
+    _DJANGO_VERSION = 18
+elif DjangoVersion[:2] == (1, 7):
     _DJANGO_VERSION = 17
 elif DjangoVersion[:2] == (1, 6):
     _DJANGO_VERSION = 16

--- a/django_pyodbc/client.py
+++ b/django_pyodbc/client.py
@@ -1,4 +1,8 @@
-from django.db.backends import BaseDatabaseClient
+try:
+    from django.db.backends.base.client import BaseDatabaseClient
+except ImportError:
+    # import location prior to Django 1.8
+    from django.db.backends import BaseDatabaseClient
 import os
 import sys
 

--- a/django_pyodbc/creation.py
+++ b/django_pyodbc/creation.py
@@ -1,7 +1,12 @@
 import base64
 import random
 
-from django.db.backends.creation import BaseDatabaseCreation
+try:
+    from django.db.backends.base.creation import BaseDatabaseCreation
+except ImportError:
+    # import location prior to Django 1.8
+    from django.db.backends.creation import BaseDatabaseCreation
+    
 
 from django_pyodbc.compat import b, md5_constructor
 
@@ -68,7 +73,11 @@ class DatabaseCreation(BaseDatabaseCreation):
             if settings_dict['TEST_NAME']:
                 test_name = settings_dict['TEST_NAME']
             else:
-                from django.db.backends.creation import TEST_DATABASE_PREFIX
+                try:
+                    from django.db.backends.base.creation import TEST_DATABASE_PREFIX
+                except ImportError:
+                    # import location prior to Django 1.8
+                    from django.db.backends.creation import TEST_DATABASE_PREFIX
                 test_name = TEST_DATABASE_PREFIX + settings_dict['NAME']
         if self.connection._DJANGO_VERSION >= 17:
             settings_dict['TEST']['NAME'] = test_name

--- a/django_pyodbc/introspection.py
+++ b/django_pyodbc/introspection.py
@@ -1,4 +1,8 @@
-from django.db.backends import BaseDatabaseIntrospection
+try:
+    from django.db.backends.base.introspection import BaseDatabaseIntrospection
+except:
+    # import location prior to Django 1.8
+    from django.db.backends import BaseDatabaseIntrospection
 import pyodbc as Database
 
 SQL_AUTOFIELD = -777555

--- a/django_pyodbc/operations.py
+++ b/django_pyodbc/operations.py
@@ -7,7 +7,12 @@ except:
     pytz = None
 
 from django.conf import settings
-from django.db.backends import BaseDatabaseOperations
+try:
+    from django.db.backends.base.operations import BaseDatabaseOperations
+except ImportError:
+    # import location prior to Django 1.8
+    from django.db.backends import BaseDatabaseOperations
+    
 
 from django_pyodbc.compat import smart_text, string_types, timezone
 


### PR DESCRIPTION
I have taken a crack at a backwards-compatible update of django_pyodbc for Django 1.8.