### PR TITLE
Fix migrate db

### DIFF
--- a/django_pyodbc/introspection.py
+++ b/django_pyodbc/introspection.py
@@ -42,10 +42,10 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """
         # TABLES: http://msdn2.microsoft.com/en-us/library/ms186224.aspx
         if cursor.db.limit_table_list:
-            cursor.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_SCHEMA = 'dbo'")
+            cursor.execute("SELECT TABLE_NAME, 't' FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_SCHEMA = 'dbo'")
         else:
-            cursor.execute("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'")
-        return [row[0] for row in cursor.fetchall()]
+            cursor.execute("SELECT TABLE_NAME, 't' FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE'")
+        return [TableInfo(row[0].lower(), row[1]) for row in cursor.fetchall()]
 
         # Or pyodbc specific:
         #return [row[2] for row in cursor.tables(tableType='TABLE')]


### PR DESCRIPTION
Fix error "
  File "C:\Python27\lib\site-packages\django-1.8.7-py2.7.egg\django\db\backends\
base\introspection.py", line 54, in <genexpr>
    if include_views or ti.type == 't')
AttributeError: 'unicode' object has no attribute 'type'"

When exec manage.py migrate|syncdb