### PR TITLE
Attribute Error when calling .count() on a queryset

### DIFF
--- a/django_pyodbc/compiler.py
+++ b/django_pyodbc/compiler.py
@@ -158,7 +158,7 @@ class SQLCompiler(compiler.SQLCompiler):
         """
         for alias, aggregate in self.query.aggregate_select.items():
             if not hasattr(aggregate, 'sql_function'):
-                return
+                continue
             if aggregate.sql_function == 'AVG':# and self.connection.cast_avg_to_float:
                 # Embed the CAST in the template on this query to
                 # maintain multi-db support.

--- a/django_pyodbc/compiler.py
+++ b/django_pyodbc/compiler.py
@@ -157,6 +157,8 @@ class SQLCompiler(compiler.SQLCompiler):
         E.g. AVG([1, 2]) needs to yield 1.5, not 1
         """
         for alias, aggregate in self.query.aggregate_select.items():
+            if not hasattr(aggregate, 'sql_function'):
+                return
             if aggregate.sql_function == 'AVG':# and self.connection.cast_avg_to_float:
                 # Embed the CAST in the template on this query to
                 # maintain multi-db support.


### PR DESCRIPTION
When calling .count() on any queryset, the following error would occur:

AttributeError: 'Count' object has no attribute 'sql_function' in the method _fix_aggregates().

The patch causes the loop in _fix_aggregates() to continue for aggregate items that do not have the sql_function attribute