### PR TITLE
Update compiler.py Workaround for Django 1.10

### DIFF
--- a/django_pyodbc/compiler.py
+++ b/django_pyodbc/compiler.py
@@ -198,7 +198,8 @@ class SQLCompiler(compiler.SQLCompiler):
         if with_limits and self.query.low_mark == self.query.high_mark:
             return '', ()
 
-        self._fix_aggregates()
+        if DjangoVersion[2] == 1 and DjangoVersion[3] < 10:
+            self._fix_aggregates()
 
         self._using_row_number = False
 


### PR DESCRIPTION
Because the Attribute `aggregate_select` was [removed in Django 1.10](https://docs.djangoproject.com/en/1.10/releases/1.10/)

But since this function is a fix for MSSQL it needs to be test with it. But it'll help if you use django-pyodbc for something other than MSSQL.

This is more like a workaround and I think it will break the support for MSSQL.
