### PR TITLE
Allow user to manually specify `left_sql_quote` and `right_sql_quote`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,11 @@ Standard Django settings
 
     Boolean.  This will trigger support for Progress Openedge
     
+* ``left_sql_quote`` , ``right_sql_quote``
+
+    String.  Specifies the string to be inserted for left and right quoting of SQL identifiers respectively.  Only set these if django-pyodbc isn't guessing the correct quoting for your system.  
+    
+    
 OpenEdge Support
 ~~~~~~~~~~~~~~~~~~~~~~~~
 For OpenEdge support make sure you supply both the deiver and the openedge extra options, all other parameters should work the same

--- a/django_pyodbc/operations.py
+++ b/django_pyodbc/operations.py
@@ -73,6 +73,8 @@ class DatabaseOperations(BaseDatabaseOperations):
         self._ss_edition = None
         self._is_db2 = None
         self._is_openedge = None
+        self._left_sql_quote = None
+        self._right_sql_quote = None
 
     @property
     def is_db2(self):
@@ -90,26 +92,38 @@ class DatabaseOperations(BaseDatabaseOperations):
     def is_openedge(self):
         if self._is_openedge is None:
             options = self.connection.settings_dict.get('OPTIONS', {})
-            self._is_openedge = 'openedge' in options and options['openedge']
+            self._is_openedge = options.get('openedge', False)
         return self._is_openedge
 
     @property
     def left_sql_quote(self):
-        if self.is_db2:
-            return '{'
-        elif self.is_openedge:
-            return '"'
-        else:
-            return '['
+        if self._left_sql_quote is None:
+            options = self.connection.settings_dict.get('OPTIONS', {})
+            q = options.get('left_sql_quote', None)
+            if q is not None:
+                self._left_sql_quote = q
+            elif self.is_db2:
+                self._left_sql_quote = '{'
+            elif self.is_openedge:
+                self._left_sql_quote = '"'
+            else:
+                self._left_sql_quote = '['
+        return self._left_sql_quote
 
     @property
     def right_sql_quote(self):
-        if self.is_db2:
-            return '}'
-        elif self.is_openedge:
-            return '"'
-        else:
-            return ']'
+        if self._right_sql_quote is None:
+            options = self.connection.settings_dict.get('OPTIONS', {})
+            q = options.get('right_sql_quote', None)
+            if q is not None:
+                self._right_sql_quote = q
+            elif self.is_db2: 
+                self._right_sql_quote = '}'
+            elif self.is_openedge:
+                self._right_sql_quote = '"'
+            else:
+                self._right_sql_quote = ']'
+        return self._right_sql_quote
 
     def _get_sql_server_ver(self):
         """


### PR DESCRIPTION
This is a fix of sorts for issue #123.  Unfortunately, IBM is a mess with their DB2 parsers and trying to guess which DB2 you have and what method of quoting its parser uses is a quagmire.  This additional support allows the user to override what django-pyodbc would have chosen.