### PR TITLE
Restore pre-Django 1.10 compatibility through function signature compatibility edit

### DIFF
--- a/django_pyodbc/compiler.py
+++ b/django_pyodbc/compiler.py
@@ -145,7 +145,10 @@ class SQLCompiler(compiler.SQLCompiler):
                 if type(val.rhs) == date or type(val.lhs) == date:
                     setattr(val, 'as_microsoft', types.MethodType(where_date, val))
 
-        return super(SQLCompiler, self).compile(node, select_format)
+        args = [node]
+        if select_format:
+            args.append(select_format)
+        return super(SQLCompiler, self).compile(*args)
 
     def resolve_columns(self, row, fields=()):
         # If the results are sliced, the resultset will have an initial


### PR DESCRIPTION
This changeset restores pre-Django 1.10 compatibility by optionally adding a parameter to `SQLCompilers.compile` method if that parameter is set, which may be true for 1.10.  If the parameter is not set, then that argument is not passed on, which makes it compatible with prior Django versions.   Tested against Django 1.7 only.