### PR TITLE
Update `pyodbc` version (to allow up to `4.0.x`).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
         'django_pyodbc.management.commands'
     ],
     install_requires=[
-        'pyodbc>=3.0.6,<3.1',
+        'pyodbc>=3.0.6,<4.1',
     ]
 )


### PR DESCRIPTION
There was no breaking changes based on [the release notes](https://github.com/mkleehammer/pyodbc/blob/master/docs/releases.md) for `pyodbc`.

`pyodbc` package is also published for Mac and Windows starting from `3.1`.