### PR TITLE
Support pip3 with encoding UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,17 @@
 
 import re
 import os
+import sys
 from django_pyodbc import metadata
+
+open_kwargs = {'encoding': 'UTF-8'} if sys.version_info.major == 3 else {}
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
+with open(os.path.join(os.path.dirname(__file__), "README.rst"), **open_kwargs) as file:
     long_description = file.read()
 
     id_regex = re.compile(r"<\#([\w-]+)>")
@@ -37,7 +40,7 @@ with open(os.path.join(os.path.dirname(__file__), "README.rst")) as file:
 
 metadata = {}
 metadata_file = "django_pyodbc/metadata.py"
-exec(compile(open(metadata_file).read(), metadata_file, 'exec'), metadata)
+exec(compile(open(metadata_file, **open_kwargs).read(), metadata_file, 'exec'), metadata)
 
 # http://pypi.python.org/pypi?:action=list_classifiers
 classifiers = [


### PR DESCRIPTION
I had trouble installing `django-pyodbc` with `pip3` in a docker container (Ubuntu `16.04`), getting the following error:

```
Collecting django_pyodbc
  Using cached django-pyodbc-1.1.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-t90de5sp/django-pyodbc/setup.py", line 27, in <module>
        long_description = file.read()
      File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
        return codecs.ascii_decode(input, self.errors)[0]
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 40: ordinal not in range(128)
```

Fixed it by checking the major Python distribution and setting an `encoding` kwarg on `open()` calls if it's equal to 3. I tested it on `pip2` manually as well, by running:

`pip2 install git+https://github.com/Akoten/django-pyodbc.git` :-)
