### PR TITLE
Two line change to convert bytes type to str if needed in Python 3.

### DIFF
--- a/django_pyodbc/base.py
+++ b/django_pyodbc/base.py
@@ -483,6 +483,8 @@ class CursorWrapper(object):
     def execute(self, sql, params=()):
         self.last_sql = sql
         sql = self.format_sql(sql, len(params))
+        if sys.version.startswith('3') and type(sql) is not str:
+            sql = sql.decode(sys.stdout.encoding)
         params = self.format_params(params)
         self.last_params = params
         try:

--- a/django_pyodbc/base.py
+++ b/django_pyodbc/base.py
@@ -454,6 +454,8 @@ class CursorWrapper(object):
         else:
             if '%s' in sql:
                 sql = sql.replace('%s', '?')
+        if sys.version.startswith('3') and type(sql) is not str:
+            sql = sql.decode(self.encoding or sys.stdout.encoding)
         return sql
 
     def format_params(self, params):
@@ -483,8 +485,6 @@ class CursorWrapper(object):
     def execute(self, sql, params=()):
         self.last_sql = sql
         sql = self.format_sql(sql, len(params))
-        if sys.version.startswith('3') and type(sql) is not str:
-            sql = sql.decode(sys.stdout.encoding)
         params = self.format_params(params)
         self.last_params = params
         try:


### PR DESCRIPTION
There may be more here... and I will update this branch if I trip on additional Python3-isms, but I was able to get django-pyodbc working with Python 3.5.4 with this two line patch.