### PR TITLE
fixing Limiting

### DIFF
--- a/django_pyodbc/compiler.py
+++ b/django_pyodbc/compiler.py
@@ -41,11 +41,12 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import re
-from django.db.models.sql import compiler, where
-import django
 import types
-from datetime import datetime, date
+from datetime import date, datetime
+
+import django
 from django import VERSION as DjangoVersion
+from django.db.models.sql import compiler, where
 
 from django_pyodbc.compat import zip_longest
 
@@ -323,7 +324,7 @@ class SQLCompiler(compiler.SQLCompiler):
                     right_sql_quote=self.connection.ops.right_sql_quote,
                 )
         else:
-            sql = "SELECT {row_num_col}, {outer} FROM ( SELECT ROW_NUMBER() OVER ( ORDER BY {order}) as {row_num_col}, {inner}) as QQQ where {where}".format(
+            sql = "SELECT {outer}, {row_num_col} FROM ( SELECT ROW_NUMBER() OVER ( ORDER BY {order}) as {row_num_col}, {inner}) as QQQ where {where}".format(
                 outer=outer_fields,
                 order=order,
                 inner=inner_select,


### PR DESCRIPTION
Django 2 changes the way the field mappings are decided, making them a static order based on model definition. Current setup pushes the row number as the first field, so all model attributes get shifted over by one.

This will put the row number at the end, which allows django to preserve the order between model definition and query output.