### PR TITLE
None params fix

### DIFF
--- a/django_pyodbc/base.py
+++ b/django_pyodbc/base.py
@@ -250,6 +250,8 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         options = settings_dict['OPTIONS']
         if settings_dict['NAME']:
             db_str = settings_dict['NAME']
+        elif settings_dict['TEST'].get('NAME'):
+            db_str = settings_dict['TEST'].get('NAME')
         if settings_dict['HOST']:
             host_str = settings_dict['HOST']
         else:
@@ -469,6 +471,9 @@ class CursorWrapper(object):
 
     def execute(self, sql, params=()):
         self.last_sql = sql
+        #django-debug toolbar error
+        if params == None:
+            params = ()
         sql = self.format_sql(sql, len(params))
         params = self.format_params(params)
         self.last_params = params

--- a/django_pyodbc/base.py
+++ b/django_pyodbc/base.py
@@ -248,10 +248,15 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         settings_dict = self.settings_dict
         db_str, user_str, passwd_str, port_str = None, None, "", None
         options = settings_dict['OPTIONS']
+        test = settings_dict['TEST']
+        try:
+            test_name = test.get('NAME')
+        except AttributeError:
+            test_name = None
         if settings_dict['NAME']:
             db_str = settings_dict['NAME']
-        elif settings_dict['TEST'].get('NAME'):
-            db_str = settings_dict['TEST'].get('NAME')
+        elif test_name:
+            db_str = test_name
         if settings_dict['HOST']:
             host_str = settings_dict['HOST']
         else:

--- a/django_pyodbc/creation.py
+++ b/django_pyodbc/creation.py
@@ -153,7 +153,7 @@ class DatabaseCreation(BaseDatabaseCreation):
         if self.connection.ops.on_azure_sql_db:
             self.connection.close()
             settings_dict["NAME"] = 'master'
-        return super(DatabaseCreation, self)._create_test_db(verbosity, autoclobber)
+        return super(DatabaseCreation, self)._create_test_db(verbosity, autoclobber, keepdb)
 
     def _destroy_test_db(self, test_database_name, verbosity):
         "Internal implementation - remove the test db tables."


### PR DESCRIPTION
- handle case where NoneType is passed for params resulting in error (error results from using django-debug-toolbar (specifically v. 1.9.1))
- pass keepdb flag from pr #161 to super
- handle case where test db name is set in Django settings