### PR TITLE
docs: Fix a few typos

### DIFF
--- a/django_pyodbc/creation.py
+++ b/django_pyodbc/creation.py
@@ -57,7 +57,7 @@ class DataTypesWrapper(dict):
     def __getitem__(self, item):
         if item in ('PositiveIntegerField', 'PositiveSmallIntegerField'):
             # The check name must be unique for the database. Add a random
-            # component so the regresion tests don't complain about duplicate names
+            # component so the regression tests don't complain about duplicate names
             fldtype = {'PositiveIntegerField': 'int', 'PositiveSmallIntegerField': 'smallint'}[item]
             rnd_hash = md5_constructor(b(str(random.random()))).hexdigest()
             unique = base64.b64encode(b(rnd_hash), b('__'))[:6]

--- a/tests/django20/aggregation_regress/tests.py
+++ b/tests/django20/aggregation_regress/tests.py
@@ -473,7 +473,7 @@ class AggregationTests(TestCase):
         )
 
         # Regression for #10182 - Queries with aggregate calls are correctly
-        # realiased when used in a subquery
+        # realised when used in a subquery
         ids = Book.objects.filter(pages__gt=100).annotate(n_authors=Count('authors')).filter(n_authors__gt=2).order_by('n_authors')
         self.assertQuerysetEqual(
             Book.objects.filter(id__in=ids), [

--- a/tests/django20/backends/tests.py
+++ b/tests/django20/backends/tests.py
@@ -515,14 +515,14 @@ class BackendTestCase(TestCase):
 
     @skipUnlessDBFeature('supports_paramstyle_pyformat')
     def test_cursor_execute_with_pyformat(self):
-        #10070: Support pyformat style passing of paramters
+        #10070: Support pyformat style passing of parameters
         args = {'root': 3, 'square': 9}
         self.create_squares(args, 'pyformat', multiple=False)
         self.assertEqual(models.Square.objects.count(), 1)
 
     @skipUnlessDBFeature('supports_paramstyle_pyformat')
     def test_cursor_executemany_with_pyformat(self):
-        #10070: Support pyformat style passing of paramters
+        #10070: Support pyformat style passing of parameters
         args = [{'root': i, 'square': i**2} for i in range(-5, 6)]
         self.create_squares(args, 'pyformat', multiple=True)
         self.assertEqual(models.Square.objects.count(), 11)

--- a/tests/django20/defer/tests.py
+++ b/tests/django20/defer/tests.py
@@ -110,7 +110,7 @@ class DeferTests(TestCase):
         obj.name = "c2"
         obj.save()
 
-        # You can retrive a single column on a base class with no fields
+        # You can retrieve a single column on a base class with no fields
         obj = Child.objects.only("name").get(name="c2")
         self.assert_delayed(obj, 3)
         self.assertEqual(obj.name, "c2")

--- a/tests/django20/multiple_database/tests.py
+++ b/tests/django20/multiple_database/tests.py
@@ -179,7 +179,7 @@ class QueryTestCase(TestCase):
         dive = Book.objects.using('other').get(title="Dive into Python")
         mark = Person.objects.using('other').get(name="Mark Pilgrim")
 
-        # Retrive related object by descriptor. Related objects should be database-baound
+        # Retrive related object by descriptor. Related objects should be database-bound
         self.assertEqual(list(dive.authors.all().values_list('name', flat=True)),
                           ['Mark Pilgrim'])
 
@@ -425,7 +425,7 @@ class QueryTestCase(TestCase):
         chris = Person.objects.using('other').get(name="Chris Mills")
         dive = Book.objects.using('other').get(title="Dive into Python")
 
-        # Retrive related object by descriptor. Related objects should be database-baound
+        # Retrive related object by descriptor. Related objects should be database-bound
         self.assertEqual(list(chris.edited.values_list('title', flat=True)),
                           ['Dive into Python'])
 
@@ -618,7 +618,7 @@ class QueryTestCase(TestCase):
         alice_profile = UserProfile.objects.using('default').get(flavor='chocolate')
         bob_profile = UserProfile.objects.using('other').get(flavor='crunchy frog')
 
-        # Retrive related object by descriptor. Related objects should be database-baound
+        # Retrive related object by descriptor. Related objects should be database-bound
         self.assertEqual(alice_profile.user.username, 'alice')
         self.assertEqual(bob_profile.user.username, 'bob')
 

--- a/tests/django20/queries/tests.py
+++ b/tests/django20/queries/tests.py
@@ -1676,7 +1676,7 @@ class DisjunctiveFilterTests(TestCase):
         # Another variation on the disjunctive filtering theme.
 
         # For the purposes of this regression test, it's important that there is no
-        # Join object releated to the LeafA we create.
+        # Join object related to the LeafA we create.
         LeafA.objects.create(data='first')
         self.assertQuerysetEqual(LeafA.objects.all(), ['<LeafA: first>'])
         self.assertQuerysetEqual(

--- a/tests/django20/timezones/tests.py
+++ b/tests/django20/timezones/tests.py
@@ -555,7 +555,7 @@ class SerializationTests(TestCase):
     # Backend-specific notes:
     # - JSON supports only milliseconds, microseconds will be truncated.
     # - PyYAML dumps the UTC offset correctly for timezone-aware datetimes,
-    #   but when it loads this representation, it substracts the offset and
+    #   but when it loads this representation, it subtracts the offset and
     #   returns a naive datetime object in UTC (http://pyyaml.org/ticket/202).
     # Tests are adapted to take these quirks into account.
 


### PR DESCRIPTION
There are small typos in:
- django_pyodbc/creation.py
- tests/django20/aggregation_regress/tests.py
- tests/django20/backends/tests.py
- tests/django20/defer/tests.py
- tests/django20/multiple_database/tests.py
- tests/django20/queries/tests.py
- tests/django20/timezones/tests.py

Fixes:
- Should read `bound` rather than `baound`.
- Should read `parameters` rather than `paramters`.
- Should read `subtracts` rather than `substracts`.
- Should read `retrieve` rather than `retrive`.
- Should read `related` rather than `releated`.
- Should read `regression` rather than `regresion`.
- Should read `realised` rather than `realiased`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md